### PR TITLE
FOGL-1129: addition of pre|post-refresh hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.snap
 parts
 prime
-snap
+snap/*
+!snap/hooks/
 stage
 *.swp
-

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+#################################################################################
+# The 'post-refresh' hook is called whenever the snap gets refreshed.
+# Contrary to `pre-refresh’, this hook is executed for the newly installed snap,
+# before starting new services (if applicable).
+# This hook is a good place for any extra actions that need to be performedi
+# for the new revision of the snap.
+#################################################################################
+
+#
+# Grab info from file INSTALLED_SNAP_INFO created by 'pre-refresh' hook
+#
+# File format is:
+# version;revision
+#
+
+__author__="Massimiliano Pinto"
+__version__="1.0"
+
+INSTALLED_SNAP_INFO="${SNAP_COMMON}/INSTALLED_SNAP_INFO"
+CURRENT_INSTALLED_VERSION=`cat ${INSTALLED_SNAP_INFO} | awk -F';' '{print $1}'`
+CURRENT_INSTALLED_REVISION=`cat ${INSTALLED_SNAP_INFO} | awk -F';' '{print $2}'`
+
+echo "post-refreshing hook of new FogLAMP being installed v${SNAP_VERSION} rev [${SNAP_REVISION}], "\
+"current installed FogLAMP is v${CURRENT_INSTALLED_VERSION}, rev [${CURRENT_INSTALLED_REVISION}]"
+
+export FOGLAMP_ROOT="${SNAP}/usr/local/foglamp"
+export CURRENT_INSTALLED_VERSION
+export CURRENT_INSTALLED_REVISION
+
+# Remove previous schema_update.log
+rm "${SNAP_COMMON}/schema_update.log" 2> /dev/null
+
+CURRENT_INSTALLED_PATH="/snap/foglamp/${CURRENT_INSTALLED_REVISION}/usr/local/foglamp"
+NEW_INSTALL_PATH="${SNAP}/usr/local/foglamp"
+
+###
+# Call check_schema_update.sh for:
+# current installed FogLAMP (CURRENT_INSTALLED_REVISION) and this new snap (SNAP) VERSION file
+#
+# Save output in SNAP_COMMON/schema_update.log
+#
+${NEW_INSTALL_PATH}/scripts/common/check_schema_update.sh "${CURRENT_INSTALLED_PATH}/VERSION" "${NEW_INSTALL_PATH}/VERSION" > "${SNAP_COMMON}/schema_update.log" 2>&1
+RET_CODE=$?
+
+###
+# Remove temp file with current FogLAMP snap revision
+#
+rm "${SNAP_COMMON}/INSTALLED_SNAP_INFO"
+
+###
+# Check check_schema_update.sh ret code
+#
+if [ "${RET_CODE}" -eq 0 ]; then
+    # Remove schema update log file
+    rm "${SNAP_COMMON}/schema_update.log"
+
+    # Return success, snap installation continues
+    exit 0
+else
+    # Add additional informations to schema_update.log
+    echo >> "${SNAP_COMMON}/schema_update.log"
+    echo "===============================" >> "${SNAP_COMMON}/schema_update.log"
+    echo "SNAP installation environement"  >> "${SNAP_COMMON}/schema_update.log"
+    echo "===============================" >> "${SNAP_COMMON}/schema_update.log"
+    env >> "${SNAP_COMMON}/schema_update.log"
+    echo "ERRORS found while performing 'check_schema_update.sh' for "\
+"new FopLAMP v${SNAP_VERSION}, See details in '${SNAP_COMMON}/schema_update.log'"
+
+    # Return failure, snap installation aborts
+    exit 1
+fi

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+######################################################################
+# The 'pre-refresh' hook is called whenever the snap gets refreshed.
+# It is executed for the already installed revision of the snapr
+# with its services still running (if the snap has any services)
+# and before switching to the newly being installed revision.
+# This hook is a good place for any maintenance or cleanup actions
+# that prepare the snap for switching to the new revision.
+#####################################################################
+#
+# Create a temp file INSTALLED_SNAP_INFO in SNAP_COMMON
+#
+# This the way we can pass current installed FogLAMP revision
+# from pre-refresh hook to post-refresh hook
+# The INSTALLED_SNAP_INFO is removed anyway by the post-refresh hook call
+#
+# File format is:
+# version;revision
+#
+
+__author__="Massimiliano Pinto"
+__version__="1.0"
+
+echo "${SNAP_VERSION};${SNAP_REVISION}" > "${SNAP_COMMON}/INSTALLED_SNAP_INFO" || exit 1
+
+exit 0


### PR DESCRIPTION
The pre-refreash hook creates INSTALLED_SNAP_INFO file in $SNAP_COMMON folder:

/var/snap/foglamp/common/INSTALLED_SNAP_INFO

with example content:
1.0.3;x1

The file is used by post-refresh hook in order to get the path of current installed snap as post-refresh only sees content in the new snap being installed

Snap installation aborts if script 'check_schema_update.sh' fails.

The file INSTALLED_SNAP_INFO is always removed while 'schema_update.log' remains in $SNAP_COMMON

Note: SNAP_USER_COMMON cannot be used here as the snap installation must be run by 'root' user and the SNAP_USER_COMMON is /root/snap/foglamp/common which is not the one of the user which starts FogLAMP


Example error on new snap installation:

```
ubuntu@ubuntu16-server-virt:~ $ sudo snap install ./foglamp_2.1.6_amd64.snap --devmode
error: cannot perform the following tasks:
- Run post-refresh hook of "foglamp" snap if present (run hook "post-refresh": 
-----
post-refreshing hook of new FogLAMP being installed v2.1.6 rev [x4], current installed FogLAMP is v2.1.5, rev [x2]
ERRORS found while performing 'check_schema_update.sh' for new FogLAMP v2.1.6, See details in '/var/snap/foglamp/common/schema_update.log'
-----)
```